### PR TITLE
[feat] add support for augment agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Initialize Davia with your coding agent:
 davia init --agent=[name of your coding agent]
 ```
 
-Replace `[name of your coding agent]` with the name of your coding agent (e.g., `cursor`, `github-copilot`, `windsurf`).
+Replace `[name of your coding agent]` with the name of your coding agent (e.g., `cursor`, `github-copilot`, `windsurf`, `claude-code`, `augment`).
 
 ### 3. Generate Documentation
 

--- a/apps/cli/src/coding-agents-options/agents/augment/index.ts
+++ b/apps/cli/src/coding-agents-options/agents/augment/index.ts
@@ -1,0 +1,14 @@
+import type { AgentConfig } from "../../types.js";
+
+export const augmentConfig: AgentConfig = {
+  name: "Augment",
+  folderPath: ".augment/rules",
+  fileName: "davia-documentation.md",
+  frontmatter: `---
+type: agent_requested
+description: Use whenever the user asks you to create, update, or read documentation/Wiki (docs, specs, design notes, API docs, etc.).
+---
+
+`,
+};
+

--- a/apps/cli/src/coding-agents-options/agents/augment/index.ts
+++ b/apps/cli/src/coding-agents-options/agents/augment/index.ts
@@ -5,10 +5,7 @@ export const augmentConfig: AgentConfig = {
   folderPath: ".augment/rules",
   fileName: "davia-documentation.md",
   frontmatter: `---
-type: agent_requested
-description: Use whenever the user asks you to create, update, or read documentation/Wiki (docs, specs, design notes, API docs, etc.).
+type: always_apply
 ---
-
 `,
 };
-

--- a/apps/cli/src/coding-agents-options/agents/index.ts
+++ b/apps/cli/src/coding-agents-options/agents/index.ts
@@ -4,6 +4,7 @@ import { windsurfConfig } from "./windsurf/index.js";
 import { githubCopilotConfig } from "./github-copilot/index.js";
 import { claudeCodeConfig } from "./claude-code/index.js";
 import { openCodeConfig } from "./open-code/index.js";
+import { augmentConfig } from "./augment/index.js";
 
 export const SUPPORTED_AGENTS: Record<string, AgentConfig> = {
   cursor: cursorConfig,
@@ -11,6 +12,7 @@ export const SUPPORTED_AGENTS: Record<string, AgentConfig> = {
   "github-copilot": githubCopilotConfig,
   "claude-code": claudeCodeConfig,
   "open-code": openCodeConfig,
+  "augment": augmentConfig,
 };
 
 export function isValidAgent(agentType: string): boolean {
@@ -27,3 +29,4 @@ export { windsurfConfig } from "./windsurf/index.js";
 export { githubCopilotConfig } from "./github-copilot/index.js";
 export { claudeCodeConfig } from "./claude-code/index.js";
 export { openCodeConfig } from "./open-code/index.js";
+export { augmentConfig } from "./augment/index.js";


### PR DESCRIPTION
Add support for augment agent i.e. `davia init --agent=augment`

Stores this information in `~/.augment/rules` as an agent_requested rule

## Testing
1. `cd apps/cli`
2. `pnpm dev init --agent=augment`
3. Successfully created `.augment/rulesdavia-documentation.md` file with contents:

```
---
type: always_apply
---

# Davia Documentation Rules

You are working in a project that uses **Davia** for all internal documentation.

## Core rule

Whenever the user asks you to create, update, or read *documentation* (docs, specs, design notes, API docs, READMEs, etc.), you **must** handle it using the Davia paradigm:

- Treat the .davia folder at the repository root as the single source of truth for project documentation.
- Prefer creating or updating Davia wiki entries inside .davia instead of creating or editing README files or other ad-hoc docs.

## Davia wiki vs README

- If the user asks for a general documentation, interpret that as a request for a **Davia wiki page** inside .davia, and implement it there instead of creating a traditional README.
- Only touch existing README files when the user explicitly instructs you to.

## Safety and instructions

Before you create, edit, or delete any files inside .davia, you **must first read** the instruction file in that folder and strictly follow its conventions when manipulating documentation files.
The instructions are in the .davia/AGENTS.md file, you **must** read it completely.

## Helpful CLI commands (for the user)

The user has access to these Davia terminal commands:

- davia open — start the Davia web server to browse and edit documentation.
- davia login — log the user into their Davia profile.

After you have generated documentation, you should **run the `davia open` command** to display the documentation in the user's browser.

Always keep all documentation work aligned with the Davia wiki structure and conventions in .davia.
```