### PR TITLE
feat: add Antigravity agent support

### DIFF
--- a/apps/cli/src/coding-agents-options/agents/antigravity/index.ts
+++ b/apps/cli/src/coding-agents-options/agents/antigravity/index.ts
@@ -1,0 +1,12 @@
+import type { AgentConfig } from "../../types.js";
+
+export const antigravityConfig: AgentConfig = {
+    name: "Antigravity",
+    folderPath: ".agent/workflows",
+    fileName: "davia-documentation.md",
+    frontmatter: `---
+description: Use whenever the user asks you to create, update, or read documentation/Wiki (docs, specs, design notes, API docs, etc.)
+---
+
+`,
+};

--- a/apps/cli/src/coding-agents-options/agents/index.ts
+++ b/apps/cli/src/coding-agents-options/agents/index.ts
@@ -5,10 +5,12 @@ import { githubCopilotConfig } from "./github-copilot/index.js";
 import { claudeCodeConfig } from "./claude-code/index.js";
 import { openCodeConfig } from "./open-code/index.js";
 import { augmentConfig } from "./augment/index.js";
+import { antigravityConfig } from "./antigravity/index.js";
 
 export const SUPPORTED_AGENTS: Record<string, AgentConfig> = {
   cursor: cursorConfig,
   windsurf: windsurfConfig,
+  antigravity: antigravityConfig,
   "github-copilot": githubCopilotConfig,
   "claude-code": claudeCodeConfig,
   "open-code": openCodeConfig,


### PR DESCRIPTION
## Description
Add support for Antigravity to `davia init` command.

## Changes

- Added apps/cli/src/coding-agents-options/agents/antigravity/index.ts - Antigravity agent configuration
- Updated apps/cli/src/coding-agents-options/agents/index.ts - Registered Antigravity in supported agents
## Usage
```bash
davia init --agent=antigravity